### PR TITLE
DIGIT-1397 Update parsec package for all platforms (android, linux and windows)

### DIFF
--- a/parsec_android/CHANGELOG.md
+++ b/parsec_android/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.4.0
+
+- Upgrade minimum Dart SDK version to 3.3.0.
+- Upgrade minimum Flutter version to 3.19.0.
+- Upgrade Android gradle version to 8.7.
+- Upgrade Android Gradle Plugin version to 8.6.1.
+- Upgrade Kotlin version to 2.1.20.
+
 ## 0.3.2
 
 - Update parsec with new functions.

--- a/parsec_android/pubspec.yaml
+++ b/parsec_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parsec_android
 description: Android implementation of the parsec plugin.
-version: 0.3.2
+version: 0.4.0
 repository: https://github.com/oxeanbits/parsec_flutter/tree/main/parsec_android
 
 environment:
@@ -10,12 +10,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  parsec_platform_interface: ^0.1.1
+  parsec_platform_interface: ^0.2.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.1
+  flutter_lints: ^4.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/parsec_linux/CHANGELOG.md
+++ b/parsec_linux/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+
+- Upgrade minimum Dart SDK version to 3.3.0.
+- Upgrade minimum Flutter version to 3.19.0.
+
 ## 0.3.1
 
 - Update parsec with new functions.

--- a/parsec_linux/pubspec.yaml
+++ b/parsec_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parsec_linux
 description: Linux implementation of the parsec plugin.
-version: 0.3.1
+version: 0.4.0
 homepage: https://github.com/oxeanbits/parsec_flutter/tree/main/parsec_linux
 repository: https://github.com/oxeanbits/parsec_flutter/tree/main/parsec_linux
 
@@ -11,12 +11,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  parsec_platform_interface: ^0.1.1
+  parsec_platform_interface: ^0.2.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.1
+  flutter_lints: ^4.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/parsec_platform_interface/CHANGELOG.md
+++ b/parsec_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0
+
+- Upgrade minimum Dart SDK version to 3.3.0.
+- Upgrade minimum Flutter version to 3.19.0.
+ 
 ## 0.1.1
 
 - Create a `ParsecEvalException` and a result parser.

--- a/parsec_platform_interface/pubspec.yaml
+++ b/parsec_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parsec_platform_interface
 description: A common platform interface for the parsec plugin.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/oxeanbits/parsec_flutter/tree/main/parsec_platform_interface
 
 environment:
@@ -10,9 +10,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.1.3
+  plugin_platform_interface: ^2.1.8
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.1
+  flutter_lints: ^4.0.0

--- a/parsec_windows/CHANGELOG.md
+++ b/parsec_windows/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0
+
+- Upgrade minimum Dart SDK version to 3.3.0.
+- Upgrade minimum Flutter version to 3.19.0.
+
 ## 0.1.0
 
 - Create Windows implementation of `parsec` plugin.

--- a/parsec_windows/pubspec.yaml
+++ b/parsec_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parsec_windows
 description: Windows implementation of the parsec plugin.
-version: 0.1.0
+version: 0.2.0
 repository: https://github.com/oxeanbits/parsec_flutter/tree/main/parsec_windows
 
 environment:
@@ -10,12 +10,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  parsec_platform_interface: ^0.1.1
+  parsec_platform_interface: ^0.2.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.1
+  flutter_lints: ^4.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
- Upgrade `parsec_android` version to 0.4.0 and upgrade the following dependencies:
  - Upgrade flutter_lints version to 4.0.0.
  - Upgrade parsec_platform_interface version to 0.2.0.
- Upgrade `parsec_linux` version to 0.4.0 and upgrade the following dependencies:
  - Upgrade flutter_lints version to 4.0.0.
  - Upgrade parsec_platform_interface version to 0.2.0.
- Upgrade `parsec_windows` version to 0.2.0 and upgrade the following dependencies:
  - Upgrade flutter_lints version to 4.0.0.
  - Upgrade parsec_platform_interface version to 0.2.0.